### PR TITLE
Fix typo WhiteList

### DIFF
--- a/Sources/LicenseCheckerModule/LCError.swift
+++ b/Sources/LicenseCheckerModule/LCError.swift
@@ -2,14 +2,14 @@ import Foundation
 
 public enum LCError: Error, LocalizedError {
     case notLoadedWorkspaceState
-    case notLoadedWiteList
+    case notLoadedWhiteList
     case forbiddenLibraryFound
 
     public var errorDescription: String? {
         switch self {
         case .notLoadedWorkspaceState:
             return "🚨 Couldn't load workspace-state.json"
-        case .notLoadedWiteList:
+        case .notLoadedWhiteList:
             return "🚨 Couldn't load white-list.json"
         case .forbiddenLibraryFound:
             return "🚨 Library with forbidden license is found."

--- a/Sources/LicenseCheckerModule/LCMain.swift
+++ b/Sources/LicenseCheckerModule/LCMain.swift
@@ -12,7 +12,7 @@ public final class LCMain {
         }
         let whiteListURL = URL(fileURLWithPath: whiteListPath)
         guard let whiteList = WhiteList.load(url: whiteListURL) else {
-            throw LCError.notLoadedWiteList
+            throw LCError.notLoadedWhiteList
         }
         let acknowledgements = packageParser.parse(with: checkoutsPath, whiteList: whiteList)
         printAcknowledgments(acknowledgements)


### PR DESCRIPTION
Fixed typo where `WhiteList` is `WiteList`.