### PR TITLE
Added new flags: verbose, quiet, tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,10 +166,10 @@ If your project directory structure is special and you want to specify the path 
 3. Add a Run Script in BuildPhases
    ```shell
    SOURCE_PACKAGES_PATH=`echo ${BUILD_DIR%Build/*}SourcePackages`
-   xcrun --sdk macosx swift package --package-path ./RoadWarriorPackages \
-     --allow-writing-to-directory ${SRCROOT} \
-     license-checker -s ${SOURCE_PACKAGES_PATH} -w [Path to white-list.json]
+   xcrun --sdk macosx swift run --package-path ${SOURCE_PACKAGES_PATH}/checkouts/LicenseChecker --disable-sandbox license-checker -s ${SOURCE_PACKAGES_PATH} -w [Path to white-list.json]
    ```
+   
+If `white-list.json` can be found in the project, you should use `${SRCROOT}` for the path to it.
 
 ## license-checker (command help)
 
@@ -179,13 +179,16 @@ Building for debugging...
 Build complete! (0.10s)
 OVERVIEW: A tool to check license of swift package libraries.
 
-USAGE: license-checker --source-packages-path <source-packages-path> --white-list-path <white-list-path>
+USAGE: license-checker --source-packages-path <source-packages-path> --white-list-path <white-list-path> [--verbose] [--quiet] [--tab]
 
 OPTIONS:
   -s, --source-packages-path <source-packages-path>
                           Path to SourcePackages directory
   -w, --white-list-path <white-list-path>
                           Path to white-list.json
+  -v, --verbose           Enable verbose output
+  -q, --quiet             Only show forbidden licenses
+  -t, --tab               Enable tab-separated output
   --version               Show the version.
   -h, --help              Show help information.
 ```

--- a/Sources/LicenseCheckerModule/Acknowledgements.swift
+++ b/Sources/LicenseCheckerModule/Acknowledgements.swift
@@ -1,5 +1,6 @@
 public struct Acknowledgement: Hashable {
-    public var libraryName: String
-    public var licenseType: LicenseType
-    public var isForbidden: Bool
+    public let libraryName: String
+    public let licenseType: LicenseType
+    public let isForbidden: Bool
+    public let location: String
 }

--- a/Sources/LicenseCheckerModule/LCMain.swift
+++ b/Sources/LicenseCheckerModule/LCMain.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class LCMain {
     public init() {}
 
-    public func run(sourcePackagesPath: String, whiteListPath: String) throws {
+    public func run(sourcePackagesPath: String, whiteListPath: String, verbose: Bool, quiet: Bool, tab: Bool) throws {
         let workspaceStateURL = URL(fileURLWithPath: sourcePackagesPath)
             .appendingPathComponent("workspace-state.json")
         let checkoutsPath = "\(sourcePackagesPath)/checkouts"
@@ -14,23 +14,55 @@ public final class LCMain {
         guard let whiteList = WhiteList.load(url: whiteListURL) else {
             throw LCError.notLoadedWhiteList
         }
-        let acknowledgements = packageParser.parse(with: checkoutsPath, whiteList: whiteList)
-        printAcknowledgments(acknowledgements)
+        var acknowledgements = packageParser.parse(with: checkoutsPath, whiteList: whiteList)
+        
+        if quiet {
+            acknowledgements = acknowledgements.filter { $0.isForbidden }
+        }
+        
+        if tab {
+            printAcknowledgmentsWithTabs(acknowledgements, verbose: verbose)
+        } else {
+            printAcknowledgments(acknowledgements, verbose: verbose)
+        }
         guard acknowledgements.allSatisfy({ $0.isForbidden == false }) else {
             throw LCError.forbiddenLibraryFound
         }
         Swift.print("✅ No problems with library licensing.")
     }
 
-    func printAcknowledgments(_ acknowledgements: [Acknowledgement]) {
-        let length = acknowledgements.max {
-            $0.libraryName.count < $1.libraryName.count
-        }?.libraryName.count ?? 0
+    func printAcknowledgments(_ acknowledgements: [Acknowledgement], verbose: Bool) {
+        let nameLength = acknowledgements.reduce(0) { max($0, $1.libraryName.count) }
+        let licenseLength = acknowledgements.reduce(0) { max($0, $1.licenseType.rawValue.count) }
+
         acknowledgements.forEach { acknowledgement in
             let mark = acknowledgement.isForbidden ? "×" : "✔︎"
             let library = acknowledgement.libraryName
-                .padding(toLength: length, withPad: " ", startingAt: 0)
-            Swift.print(mark, library, acknowledgement.licenseType.rawValue)
+                .padding(toLength: nameLength, withPad: " ", startingAt: 0)
+            if verbose {
+                let license = acknowledgement.licenseType.rawValue
+                    .padding(toLength: licenseLength, withPad: " ", startingAt: 0)
+                Swift.print(mark, library, license, acknowledgement.location)
+            } else {
+                Swift.print(mark, library, acknowledgement.licenseType.rawValue)
+            }
         }
     }
+
+    func printAcknowledgmentsWithTabs(_ acknowledgements: [Acknowledgement], verbose: Bool) {
+        acknowledgements.forEach { acknowledgement in
+            let mark = acknowledgement.isForbidden ? "×" : "✔︎"
+            
+            var row = [
+                mark,
+                acknowledgement.libraryName,
+                acknowledgement.licenseType.rawValue
+            ]
+            if verbose {
+                row.append(acknowledgement.location)
+            }
+            Swift.print(row.joined(separator: "\t"))
+        }
+    }
+    
 }

--- a/Sources/LicenseCheckerModule/PackageParser.swift
+++ b/Sources/LicenseCheckerModule/PackageParser.swift
@@ -23,7 +23,8 @@ public struct PackageParser {
                 return Acknowledgement(
                     libraryName: libraryName,
                     licenseType: licenseType,
-                    isForbidden: isForbidden
+                    isForbidden: isForbidden,
+                    location: dependency.packageRef.location
                 )
             }
             .sorted { $0.libraryName.lowercased() < $1.libraryName.lowercased() }

--- a/Sources/license-checker/LicenseChecker.swift
+++ b/Sources/license-checker/LicenseChecker.swift
@@ -20,12 +20,33 @@ struct LicenseChecker: ParsableCommand {
         help: "Path to white-list.json"
     )
     var whiteListPath: String
+    
+    @Flag(
+        name: [.customShort("v"), .customLong("verbose")],
+        help: "Enable verbose output"
+    )
+    var verbose: Bool = false
+    
+    @Flag(
+        name: [.customShort("q"), .customLong("quiet")],
+        help: "Only show forbidden licenses"
+    )
+    var quiet: Bool = false
+    
+    @Flag(
+        name: [.customShort("t"), .customLong("tab")],
+        help: "Enable tab-separated output"
+    )
+    var tab: Bool = false
 
     mutating func run() throws {
         do {
             try LCMain().run(
                 sourcePackagesPath: sourcePackagesPath,
-                whiteListPath: whiteListPath
+                whiteListPath: whiteListPath,
+                verbose: verbose,
+                quiet: quiet,
+                tab: tab
             )
         } catch let error as LCError {
             Swift.print("error:", error.errorDescription!)


### PR DESCRIPTION
This adds three flags:
- v / verbose : also show the URL of the package
- q / quiet : only show forbidden libraries
- t / tab : outputs tab-separated output to copy to Excel, Numbers