### PR TITLE
Changed to use repository name instead of package name for white list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ $
 0. Prepare a white list (`white-list.json`).
 
 - Specify the type of license to approve.
-- Specify the name of library to approve (for private libraries).
+- Specify the repository name of library to approve (for private libraries).
 
 LicenseChecker supports the following licenses:
 
@@ -73,7 +73,7 @@ LicenseChecker supports the following licenses:
     "BoringSSL"
   ],
   "libraries": [
-    "PrivateLibrary-Hoge"
+    "private-library-hoge"
   ]
 }
 ```

--- a/Sources/LicenseCheckerModule/PackageParser.swift
+++ b/Sources/LicenseCheckerModule/PackageParser.swift
@@ -18,8 +18,9 @@ public struct PackageParser {
                 let repositoryName = components.last!.replacingOccurrences(of: ".git", with: "")
                 let directoryURL = URL(fileURLWithPath: checkoutsPath).appendingPathComponent(repositoryName)
                 let libraryName = dependency.packageRef.name
+                let libraryID = dependency.packageRef.identity
                 let licenseType = extractLicense(directoryURL: directoryURL)
-                let isForbidden = !whiteList.contains(libraryName, licenseType: licenseType)
+                let isForbidden = !whiteList.contains(libraryID: libraryID, licenseType: licenseType)
                 return Acknowledgement(
                     libraryName: libraryName,
                     licenseType: licenseType,

--- a/Sources/LicenseCheckerModule/WhiteList.swift
+++ b/Sources/LicenseCheckerModule/WhiteList.swift
@@ -17,8 +17,8 @@ public struct WhiteList: Decodable {
         self = whiteList
     }
 
-    public func contains(_ libraryName: String, licenseType: LicenseType) -> Bool {
-        if let libraries, libraries.contains(libraryName) {
+    public func contains(libraryID: String, licenseType: LicenseType) -> Bool {
+        if let libraries, libraries.contains(libraryID) {
             true
         } else if licenseType == .unknown {
             false


### PR DESCRIPTION
I changed the specification of libraries in the whitelist to use the repository name of the package instead of the package name.

When the Swift Package Manager fetches a repository based on `Package.swift`, there can be ambiguity in determining the repository name.

For instance, if the repository name is `sample-kit` and the package name is `SampleKit`, looking at `workspace-state.json`, `packageRef.name` can sometimes be `sample-kit` and sometimes `SampleKit`. 

This judgment of the name can fluctuate even by simply changing the specified library version without altering the way `Package.swift` is written. As it's highly risky to specify something unstable as a whitelist, we decided to use the uniquely determined `packageRef.identity` instead of `packageRef.name`.