### PR TITLE
Compare LibraryIDs in lowercase.

### DIFF
--- a/Sources/LicenseCheckerModule/PackageParser.swift
+++ b/Sources/LicenseCheckerModule/PackageParser.swift
@@ -20,7 +20,7 @@ public struct PackageParser {
                 let libraryName = dependency.packageRef.name
                 let libraryID = dependency.packageRef.identity
                 let licenseType = extractLicense(directoryURL: directoryURL)
-                let isForbidden = !whiteList.contains(libraryID: libraryID, licenseType: licenseType)
+                let isForbidden = !(whiteList.contains(libraryID: libraryID) || whiteList.contains(licenseType: licenseType))
                 return Acknowledgement(
                     libraryName: libraryName,
                     licenseType: licenseType,

--- a/Sources/LicenseCheckerModule/WhiteList.swift
+++ b/Sources/LicenseCheckerModule/WhiteList.swift
@@ -17,10 +17,16 @@ public struct WhiteList: Decodable {
         self = whiteList
     }
 
-    public func contains(libraryID: String, licenseType: LicenseType) -> Bool {
-        if let libraries, libraries.contains(libraryID) {
-            true
-        } else if licenseType == .unknown {
+    public func contains(libraryID: String) -> Bool {
+        if let libraries {
+            libraries.map({ $0.lowercased() }).contains(libraryID.lowercased())
+        } else {
+            false
+        }
+    }
+
+    public func contains(licenseType: LicenseType) -> Bool {
+        if licenseType == .unknown {
             false
         } else if let licenses {
             licenses.map({ $0.lowercased() }).contains(licenseType.lowercased)


### PR DESCRIPTION
Comparisons of `packageRef.identity` must be done in lowercase.